### PR TITLE
マークダウンファイルの先頭にYAMLを埋め込む

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /doc/
 /pkg/
 /spec/reports/
-/spec/exports/
 /tmp/
 
 # rspec failure tracking

--- a/lib/scrapbox2markdown/file_generator.rb
+++ b/lib/scrapbox2markdown/file_generator.rb
@@ -11,9 +11,10 @@ module Scrapbox2markdown
     def generate
       pages = import("#{@input}")
       pages.each do |page|
+        header = yaml_header(page)
         lines = page['lines'].map(&:chomp)
         Scrapbox2markdown::Converter.new(lines).convert!
-        export(lines: lines, filename: page['title'])
+        export(lines: lines.prepend(header), filename: page['title'])
       end
     end
 
@@ -34,6 +35,24 @@ module Scrapbox2markdown
       File.open("#{output_dir}/#{filename}.md", "w") do |io|
         lines.each { |line| io.puts(line) }
       end
+    end
+
+    # Markdownファイルの先頭に埋め込むため、YAML形式で出力する
+    # ---
+    # title: "はじめに"
+    # created_at: 2018-03-26 22:52:30 +0900
+    # updated_at: 2018-04-21 11:51:09 +0900
+    # ---
+    #
+    def yaml_header(page)
+      <<~YAML
+      ---
+      title: "#{page['title']}"
+      created_at: #{Time.at(page['created'])}
+      updated_at: #{Time.at(page['updated'])}
+      ---
+
+      YAML
     end
   end
 end

--- a/lib/scrapbox2markdown/file_generator.rb
+++ b/lib/scrapbox2markdown/file_generator.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'json'
+require 'yaml'
 
 module Scrapbox2markdown
   class FileGenerator
@@ -11,10 +12,9 @@ module Scrapbox2markdown
     def generate
       pages = import("#{@input}")
       pages.each do |page|
-        header = yaml_header(page)
         lines = page['lines'].map(&:chomp)
         Scrapbox2markdown::Converter.new(lines).convert!
-        export(lines: lines.prepend(header), filename: page['title'])
+        export(lines: lines.prepend(yaml_header(page), "---\n\n"), filename: page['title'])
       end
     end
 
@@ -39,20 +39,15 @@ module Scrapbox2markdown
 
     # Markdownファイルの先頭に埋め込むため、YAML形式で出力する
     # ---
-    # title: "はじめに"
+    # title: はじめに
     # created_at: 2018-03-26 22:52:30 +0900
     # updated_at: 2018-04-21 11:51:09 +0900
     # ---
     #
     def yaml_header(page)
-      <<~YAML
-      ---
-      title: "#{page['title']}"
-      created_at: #{Time.at(page['created'])}
-      updated_at: #{Time.at(page['updated'])}
-      ---
-
-      YAML
+      { "title" => page['title'],
+        "created_at" => Time.at(page['created']),
+        "updated_at" => Time.at(page['updated']) }.to_yaml
     end
   end
 end

--- a/spec/scrapbox2markdown/file_generator_spec.rb
+++ b/spec/scrapbox2markdown/file_generator_spec.rb
@@ -2,11 +2,33 @@ require 'pathname'
 
 RSpec.describe Scrapbox2markdown::FileGenerator do
   output_path = 'tmp'
-  it "generates .md from .json to #{output_path}" do
+  it "should generate .md from .json to #{output_path}" do
     # カレントディレクトリの.jsonからテスト用ディレクトリに.mdを生成する
     file_generator = Scrapbox2markdown::FileGenerator.new('test.json', "#{output_path}")
     file_generator.generate
     expect(Dir.exist?("./#{output_path}")).to be true
     expect(Dir.empty?("./#{output_path}")).to be false
+  end
+
+  describe 'Embedded YAML metadata' do
+    shared_examples 'YAML metadata' do |path, to_be_loaded|
+      it 'should be able to load YAML metadata ' do
+        open(path) do |file|
+          expect(YAML.load(file.read)).to eq to_be_loaded
+        end
+      end
+    end
+
+    include_examples 'YAML metadata',
+                     './tmp/はじめに.md',
+                     { "title"      => "はじめに",
+                       "created_at" => Time.new(2018, 03, 26, 22, 52, 30, '+09:00'),
+                       "updated_at" => Time.new(2018, 04, 21, 11, 51,  9, '+09:00') }
+
+    include_examples 'YAML metadata',
+                     './tmp/健康診断.md',
+                     { "title"      =>"健康診断",
+                       "created_at" => Time.new(2018, 03, 26, 22, 54, 19, '+09:00'),
+                       "updated_at" => Time.new(2018, 03, 26, 22, 55, 54, '+09:00') }
   end
 end

--- a/spec/scrapbox2markdown/file_generator_spec.rb
+++ b/spec/scrapbox2markdown/file_generator_spec.rb
@@ -1,7 +1,7 @@
 require 'pathname'
 
 RSpec.describe Scrapbox2markdown::FileGenerator do
-  output_path = 'spec/exports/generated'
+  output_path = 'tmp'
   it "generates .md from .json to #{output_path}" do
     # カレントディレクトリの.jsonからテスト用ディレクトリに.mdを生成する
     file_generator = Scrapbox2markdown::FileGenerator.new('test.json', "#{output_path}")


### PR DESCRIPTION
Closes #4 

JSONから`title`, `created`, `updated` の値を取り出し、以下の形式にしてマークダウンに埋め込む

```yaml
---
title: "はじめに"
created_at: 2018-03-26 22:52:30 +0900
updated_at: 2018-04-21 11:51:09 +0900
---

（ここから本文）
```

インポートする際に例えば以下のようにする

https://help.docbase.io/posts/46870?list=%2Fsearch&q=%E3%82%A4%E3%83%B3%E3%83%9D%E3%83%BC%E3%83%88

```rb
    post_json = {
      title:  "#{data['title']}",
      (snip)
      published_at: data['created_at'].iso8601,
    }.to_json
```
